### PR TITLE
Fix month view dates

### DIFF
--- a/frontend/src/use-cases/home/views/calendar.view.jsx
+++ b/frontend/src/use-cases/home/views/calendar.view.jsx
@@ -37,6 +37,7 @@ const Calendar = ({ getEvents, eventClick, onSelect, onEventDrop, ref }) => {
         hour12: false,
       }}
       dayHeaderFormat={"ddd DD/MM"}
+      views={{dayGridMonth: {dayHeaderFormat: "ddd"}}}
       rerenderDelay={1000}
       allDaySlot
       weekNumbers


### PR DESCRIPTION
This PR adds a custom `dayHeaderFormat` for month view that does not include the date markers.
Fixes #68 