### PR TITLE
Same-day rules

### DIFF
--- a/backend/src/services/rule.service.ts
+++ b/backend/src/services/rule.service.ts
@@ -186,6 +186,10 @@ export const checkRules = async (prisma: PrismaClient, event: Event) => {
 };
 
 const validDate = (start: Date, end: Date): boolean => {
+  return start.getTime() > 0 && end.getTime() > 0 && start <= end;
+};
+
+const validDateTime = (start: Date, end: Date): boolean => {
   return start.getTime() > 0 && end.getTime() > 0 && start < end;
 };
 
@@ -213,7 +217,7 @@ export const createRule = async (
 
   const start_time = new Date(rule.start_date + "T" + rule.start_time);
   const end_time = new Date(rule.start_date + "T" + rule.end_time);
-  if (!validDate(start_time, end_time)) {
+  if (!validDateTime(start_time, end_time)) {
     return {
       sv: "Ogiltig tid",
       en: "Invalid time",


### PR DESCRIPTION
There have been instances where rules have had to be created that would only last for one day. Attempting to do this would return "Invalid date", as it occurs on the same date.
This PR is a simple patch that changes `validDate` to allow `start` to be less than or equal to `end`, and moves the previous functionality into `validDateTime` (where `start` can only be less than `end`).